### PR TITLE
Implement QR code image endpoint and refactor controller

### DIFF
--- a/src/qrcodeapi/TaskController.java
+++ b/src/qrcodeapi/TaskController.java
@@ -2,6 +2,14 @@ package qrcodeapi;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+
 
 @RestController
 public class TaskController {
@@ -12,8 +20,24 @@ public class TaskController {
     }
 
     @GetMapping("/api/qrcode")
-    public ResponseEntity<String> qrcode() {
-        return new ResponseEntity<>("NOT IMPLEMENTED", HttpStatus.NOT_IMPLEMENTED);
-    }
+    public ResponseEntity<byte[]> getImage() {
+        int width = 250;
+        int height = 250;
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = image.createGraphics();
 
+        g.setColor(Color.WHITE);
+        g.fillRect(0,0, width, height);
+
+        try (var baos = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "png", baos);
+            byte[] bytes = baos.toByteArray();
+            return ResponseEntity
+                    .ok()
+                    .contentType(MediaType.IMAGE_PNG)
+                    .body(bytes);
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 }


### PR DESCRIPTION
- Added /api/qrcode endpoint that returns a 250x250 white PNG image
- Used BufferedImage and Graphics2D for dynamic image creation
- Set proper Content-Type header (image/png)
- Updated error handling to return 500 on failure
- Refactored controller responses to use ResponseEntity