### PR TITLE
Add support for dynamic image size and format in /api/qrcode endpoint

### DIFF
--- a/src/qrcodeapi/TaskController.java
+++ b/src/qrcodeapi/TaskController.java
@@ -8,6 +8,9 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
 import org.springframework.http.MediaType;
 
 
@@ -19,25 +22,48 @@ public class TaskController {
         return new ResponseEntity<>("OK", HttpStatus.OK);
     }
 
+
     @GetMapping("/api/qrcode")
-    public ResponseEntity<byte[]> getImage() {
-        int width = 250;
-        int height = 250;
-        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g = image.createGraphics();
+    public ResponseEntity<?> getImage(
+            @RequestParam(name = "size") int size,
+            @RequestParam(name = "type") String type) {
+        if (size < 150 || size > 350) {
+            return ResponseEntity
+                    .badRequest()
+                    .body("{\"error\": \"Image size must be between 150 and 350 pixels\"}");
+        }
 
-        g.setColor(Color.WHITE);
-        g.fillRect(0,0, width, height);
+        if (!type.equalsIgnoreCase("png") && !type.equalsIgnoreCase("jpeg") && !type.equalsIgnoreCase("gif")) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(Map.of("error", "Only png, jpeg and gif image types are supported"));
+        }
 
-        try (var baos = new ByteArrayOutputStream()) {
-            ImageIO.write(image, "png", baos);
+        try {
+            BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
+            Graphics2D g = image.createGraphics();
+            g.setColor(Color.WHITE);
+            g.fillRect(0, 0, size, size);
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(image, type.toLowerCase(), baos);
             byte[] bytes = baos.toByteArray();
+
+            MediaType imageFormatSelected = switch (type.toLowerCase()) {
+                case "png" -> MediaType.IMAGE_PNG;
+                case "jpeg" -> MediaType.IMAGE_JPEG;
+                case "gif" -> MediaType.IMAGE_GIF;
+                default -> MediaType.IMAGE_PNG;
+            };
+
             return ResponseEntity
                     .ok()
-                    .contentType(MediaType.IMAGE_PNG)
+                    .contentType(imageFormatSelected)
                     .body(bytes);
+
         } catch (IOException e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 }
+


### PR DESCRIPTION
- Added `size` query param (must be between 150–350)
- Added `type` query param (supports png, jpeg, gif)
- Validates both parameters and returns 400 BAD REQUEST with JSON error messages when invalid
- Dynamically sets image size and format based on input
- Sets proper Content-Type header for each format
- Improved route to support Spring's param binding without debug symbols